### PR TITLE
biotool.R to read from stdin, add README

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -2,14 +2,12 @@
 
 ## Installation
 
-Download R from [CRAN](https://www.r-project.org/). biotool.R was tested on R version 3.2.4.
+Download R from [CRAN](https://www.r-project.org/) and follow the instructions
+there to install it. biotool.R was tested on R version 3.2.
 
-Install dependancies:
-```
-$ R
-
-> install.packages(c("argparse", "seqinr"))
-> q()
+Install R packages:
+```bash
+Rscript -e "install.packages(c("argparse", "seqinr"), repos='http://cran.rstudio.org')"
 ```
 
 ## Usage

--- a/r/README.md
+++ b/r/README.md
@@ -1,0 +1,17 @@
+# biotool.R
+
+## Installation
+
+Download R from [CRAN](https://www.r-project.org/). biotool.R was tested on R version 3.2.4.
+
+Install dependancies:
+```
+$ R
+
+> install.packages(c("argparse", "seqinr"))
+> q()
+```
+
+## Usage
+
+./biotool.R FASTA_FILE

--- a/r/biotool.R
+++ b/r/biotool.R
@@ -8,8 +8,8 @@ suppressWarnings({
 })
 
 parser <- ArgumentParser(description="Print FASTA stats")
-parser$add_argument("fasta_files", metavar="FASTA_FILE", type="character", nargs="?", default="stdin",
-                    help="Input FASTA files")
+parser$add_argument("fasta_files", metavar="FASTA_FILE", type="character", nargs="+",
+                    help="Input FASTA files. Use - to read from stdin")
 parser$add_argument("--minlen", metavar="N", type="integer", dest="min_len", default=0,
                     help="Minimum length sequence to include in stats [default: %(default)s]")
 parser$add_argument("--verbose", dest="verbose", action="store_true",
@@ -25,6 +25,9 @@ if ("--version" %in% commandArgs()) {
 
 # Process command line arguments
 args <- parser$parse_args()
+
+# Read from stdin if file is '-'
+args$fasta_files[args$fasta_files == '-'] <- 'stdin'
 
 # Get statistics of a FASTA file
 get_fasta_stats <- function(filename, min_len) {
@@ -57,7 +60,7 @@ get_fasta_stats <- function(filename, min_len) {
 
 # Check if FASTA files exist
 exists <- sapply(args$fasta_files, file.exists)
-exists <- args$fasta_files == 'stdin'
+exists[args$fasta_files == 'stdin'] <- TRUE
 if (any(! exists)) {
   stop("File does not exist:\n\t", paste(args$fasta_files[! exists], collapse="\n\t"))
 }


### PR DESCRIPTION
Hey @jessicachung, I got biotool.R to read from stdin in the absence of an input file. The downside is that if no arguments are given it just hangs, and you have to kill it (unfortunately R scripts tend to ignore ctl-c, so this is not always obvious what to do). Any idea how to fix that?

Also started a readme. My brief googling didn't come up with a best practise for installing R dependancies without actually entering the R interactive environment. Any thoughts?